### PR TITLE
Add monthly view mode option for Datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ![Improvely.com](http://i.imgur.com/LbAMf3D.png)
 
 This date range picker component for Bootstrap creates a dropdown menu from which a user can
-select a range of dates. I created it while building the UI for [Improvely](http://www.improvely.com), 
+select a range of dates. I created it while building the UI for [Improvely](http://www.improvely.com),
 which needed a way to select date ranges for reports.
 
-If invoked with no options, it will present two calendars to choose a start 
-and end date from. Optionally, you can provide a list of date ranges the user can select from instead 
-of choosing dates from the calendars. If attached to a text input, the selected dates will be inserted 
+If invoked with no options, it will present two calendars to choose a start
+and end date from. Optionally, you can provide a list of date ranges the user can select from instead
+of choosing dates from the calendars. If attached to a text input, the selected dates will be inserted
 into the text box. Otherwise, you can provide a custom callback function to receive the selection.
 
 The component can also be used as a single date picker by setting the `singleDatePicker` option to `true`.
@@ -38,14 +38,14 @@ $(document).ready(function() {
 </script>
 ```
 
-The constructor also takes an optional options object and callback function. The function will be called whenever 
+The constructor also takes an optional options object and callback function. The function will be called whenever
 the selected date range has been changed by the user, and is passed the start and end dates (moment date objects)
-and the predefined range label chosen (if any), as parameters. It will not fire if the picker is closed without 
+and the predefined range label chosen (if any), as parameters. It will not fire if the picker is closed without
 any change to the selected dates.
 
 ````
 $('input[name="daterange"]').daterangepicker(
-  { 
+  {
     format: 'YYYY-MM-DD',
     startDate: '2013-01-01',
     endDate: '2013-12-31'
@@ -57,6 +57,8 @@ $('input[name="daterange"]').daterangepicker(
 ````
 
 ## Options
+
+`viewMode`: (string: 'day'/'month') Whether the calendar will be in daily or monthly mode
 
 `startDate`: (Date object, moment object or string) The start of the initially selected date range
 
@@ -147,7 +149,7 @@ Some applications need a "clear" instead of a "cancel" functionality, which can 
 
 ````
 $('#daterange').daterangepicker({
-  locale: { cancelLabel: 'Clear' }  
+  locale: { cancelLabel: 'Clear' }
 });
 
 $('#daterange').on('cancel.daterangepicker', function(ev, picker) {

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -168,7 +168,7 @@
 .daterangepicker.openscenter:before {
   position: absolute;
   top: -7px;
-  left: 0;  
+  left: 0;
   right: 0;
   width: 0;
   margin-left: auto;
@@ -184,8 +184,8 @@
 .daterangepicker.openscenter:after {
   position: absolute;
   top: -6px;
-  left: 0;  
-  right: 0;  
+  left: 0;
+  right: 0;
   width: 0;
   margin-left: auto;
   margin-right: auto;
@@ -326,10 +326,16 @@
 }
 
 .daterangepicker_end_input {
-  float: left; 
+  float: left;
   padding-left: 11px
 }
 
 .daterangepicker th.month {
   width: auto;
+}
+
+.daterangepicker td.month {
+  width: 56px;
+  height: 54px;
+  margin: 2px;
 }

--- a/examples.html
+++ b/examples.html
@@ -28,7 +28,7 @@
                   <div class="control-group">
                     <div class="controls">
                      <div class="input-prepend input-group">
-                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="reservation" id="reservation" class="form-control" value="03/18/2013 - 03/23/2013" /> 
+                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="reservation" id="reservation" class="form-control" value="03/18/2013 - 03/23/2013" />
                      </div>
                     </div>
                   </div>
@@ -54,7 +54,7 @@
                   <div class="control-group">
                     <div class="controls">
                      <div class="input-prepend input-group">
-                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="birthday" id="birthday" class="form-control" value="03/18/2013" /> 
+                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="birthday" id="birthday" class="form-control" value="03/18/2013" />
                      </div>
                     </div>
                   </div>
@@ -100,7 +100,7 @@
                });
                </script>
 
-            </div>            
+            </div>
 
             <h4>Options Usage</h4>
 
@@ -183,12 +183,12 @@
 
                   $('#reportrange').on('show.daterangepicker', function() { console.log("show event fired"); });
                   $('#reportrange').on('hide.daterangepicker', function() { console.log("hide event fired"); });
-                  $('#reportrange').on('apply.daterangepicker', function(ev, picker) { 
-                    console.log("apply event fired, start/end dates are " 
-                      + picker.startDate.format('MMMM D, YYYY') 
-                      + " to " 
+                  $('#reportrange').on('apply.daterangepicker', function(ev, picker) {
+                    console.log("apply event fired, start/end dates are "
+                      + picker.startDate.format('MMMM D, YYYY')
+                      + " to "
                       + picker.endDate.format('MMMM D, YYYY')
-                    ); 
+                    );
                   });
                   $('#reportrange').on('cancel.daterangepicker', function(ev, picker) { console.log("cancel event fired"); });
 
@@ -247,7 +247,7 @@
                   <div class="control-group">
                     <div class="controls">
                      <div class="input-prepend input-group">
-                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="dropup" id="dropup" class="form-control" value="03/18/2013 - 03/23/2013" /> 
+                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="dropup" id="dropup" class="form-control" value="03/18/2013 - 03/23/2013" />
                      </div>
                     </div>
                   </div>
@@ -264,6 +264,31 @@
 
             </div>
 
+            <h4>Monthly calendar</h4>
+
+            <div class="well">
+
+               <form class="form-horizontal">
+                 <fieldset>
+                  <div class="control-group">
+                    <div class="controls">
+                     <div class="input-prepend input-group">
+                       <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span><input type="text" style="width: 200px" name="dropup" id="monthly_cal" class="form-control" value="03/18/2013 - 03/23/2013" />
+                     </div>
+                    </div>
+                  </div>
+                 </fieldset>
+               </form>
+
+               <script type="text/javascript">
+               $(document).ready(function() {
+                  $('#monthly_cal').daterangepicker({
+                    viewMode: 'month'
+                  });
+               });
+               </script>
+
+            </div>
 
          </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-daterangepicker",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "Date range picker component for Bootstrap",
   "main": "daterangepicker.js",
   "style": "daterangepicker-bs3.css",


### PR DESCRIPTION
This repository is forked from Dan Grossman's [bootstrap datepicker](https://github.com/dangrossman/daterangepicker) and does not offer a monthly view mode, neither the original, nor this fork. Dan says it is not available and [not planned](https://github.com/dangrossman/daterangepicker/issues/315) and recommends to use [dropdowns for months](https://github.com/dangrossman/daterangepicker/issues/1759) instead. But the original repository contains a closed [PR](https://github.com/dangrossman/daterangepicker/pull/1496) which implements a monthly view. We use this code to add the desired monthly view feature.

![screen shot 2019-01-07 at 15 41 54](https://user-images.githubusercontent.com/5287540/50774064-d5065d00-1292-11e9-9d65-f624beb2a704.png)
